### PR TITLE
Remove resyncPeriods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,12 @@ pod communication.
 
 ```
 Usage of ./semaphore-policy:
-  -full-store-resync-period duration
-        Frequency to perform a full network set store resync from cache to calico GlocalNetworkPolicies (default 1h0m0s)
   -local-kube-config string
         Path of the local kube cluster config file, if not provided the app will try to get in cluster config
   -log-level string
         Log level (default "info")
   -pod-resync-period duration
-        Pod watcher cache resync period (default 1h0m0s)
+        Pod watcher cache resync period. Disabled by default
   -remote-api-url string
         Remote Kubernetes API server URL
   -remote-ca-url string

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/utilitywarehouse/semaphore-policy/calico"
@@ -26,15 +25,14 @@ const (
 )
 
 var (
-	flagKubeConfigPath        = flag.String("local-kube-config", getEnv("SP_LOCAL_KUBE_CONFIG", ""), "Path of the local kube cluster config file, if not provided the app will try to get in cluster config")
-	flagTargetKubeConfigPath  = flag.String("target-kube-config", getEnv("SP_TARGET_KUBE_CONFIG", ""), "(Required) Path of the target cluster kube config file to watch pods")
-	flagLogLevel              = flag.String("log-level", getEnv("SP_LOG_LEVEL", "info"), "Log level")
-	flagRemoteAPIURL          = flag.String("remote-api-url", getEnv("SP_REMOTE_API_URL", ""), "Remote Kubernetes API server URL")
-	flagRemoteCAURL           = flag.String("remote-ca-url", getEnv("SP_REMOTE_CA_URL", ""), "Remote Kubernetes CA certificate URL")
-	flagRemoteSATokenPath     = flag.String("remote-sa-token-path", getEnv("SP_REMOTE_SERVICE_ACCOUNT_TOKEN_PATH", ""), "Remote Kubernetes cluster token path")
-	flagFullStoreResyncPeriod = flag.Duration("full-store-resync-period", 60*time.Minute, "Frequency to perform a full network set store resync from cache to calico GlocalNetworkPolicies")
-	flagPodResyncPeriod       = flag.Duration("pod-resync-period", 60*time.Minute, "Pod watcher cache resync period")
-	flagTargetCluster         = flag.String("target-cluster-name", getEnv("SP_TARGET_CLUSTER_NAME", ""), "(required) The name of the cluster from which pods are synced as networksets. It will also be used as a prefix used when creating network sets.")
+	flagKubeConfigPath       = flag.String("local-kube-config", getEnv("SP_LOCAL_KUBE_CONFIG", ""), "Path of the local kube cluster config file, if not provided the app will try to get in cluster config")
+	flagTargetKubeConfigPath = flag.String("target-kube-config", getEnv("SP_TARGET_KUBE_CONFIG", ""), "(Required) Path of the target cluster kube config file to watch pods")
+	flagLogLevel             = flag.String("log-level", getEnv("SP_LOG_LEVEL", "info"), "Log level")
+	flagRemoteAPIURL         = flag.String("remote-api-url", getEnv("SP_REMOTE_API_URL", ""), "Remote Kubernetes API server URL")
+	flagRemoteCAURL          = flag.String("remote-ca-url", getEnv("SP_REMOTE_CA_URL", ""), "Remote Kubernetes CA certificate URL")
+	flagRemoteSATokenPath    = flag.String("remote-sa-token-path", getEnv("SP_REMOTE_SERVICE_ACCOUNT_TOKEN_PATH", ""), "Remote Kubernetes cluster token path")
+	flagPodResyncPeriod      = flag.Duration("pod-resync-period", 0, "Pod watcher cache resync period. Disabled by default")
+	flagTargetCluster        = flag.String("target-cluster-name", getEnv("SP_TARGET_CLUSTER_NAME", ""), "(required) The name of the cluster from which pods are synced as networksets. It will also be used as a prefix used when creating network sets.")
 
 	saToken  = os.Getenv("SP_REMOTE_SERVICE_ACCOUNT_TOKEN")
 	bearerRe = regexp.MustCompile(`[A-Z|a-z0-9\-\._~\+\/]+=*`)
@@ -105,14 +103,12 @@ func main() {
 		homeCalicoClient,
 		remoteClient,
 		*flagTargetCluster,
-		*flagFullStoreResyncPeriod,
 		*flagPodResyncPeriod,
 	)
 	if err := r.Start(); err != nil {
 		log.Logger.Error("Failed to start runner", "err", err)
 		os.Exit(1)
 	}
-	go r.Run()
 
 	sm := http.NewServeMux()
 	sm.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
Set watcher's resyncPeriod to 0 as we should be handling all events and
requeueing if needed. Disable the full store sync every hour as it seems
redundant and only keep the initial full resync on startup after the caches are
synced.