### PR TITLE
metrics: initialize counters with 0 value

### DIFF
--- a/networksets.go
+++ b/networksets.go
@@ -156,7 +156,7 @@ func (nss *NetworkSetStore) RunSyncLoop() {
 
 func (nss *NetworkSetStore) requeue(id string) {
 	log.Logger.Debug("Requeueing sync task", "id", id)
-	metrics.IncSyncRequeue(id)
+	metrics.IncSyncRequeue()
 	go func() {
 		time.Sleep(1)
 		nss.enqueue(id)
@@ -170,7 +170,7 @@ func (nss *NetworkSetStore) enqueue(id string) {
 		log.Logger.Debug("Sync task queued", "id", id)
 	case <-time.After(5 * time.Second):
 		log.Logger.Error("Timed out trying to queue a sync action for netset, run queue is full", "id", id)
-		metrics.IncSyncQueueFullFailures(id)
+		metrics.IncSyncQueueFullFailures()
 		nss.requeue(id)
 	}
 }


### PR DESCRIPTION
The increase() function  won't recognise a move from no value -> 1 as an increase, which means it's possible for alerts to miss events.

To address this, initialize every possible set of labels for each counter with a 0 value.

The `semaphore_policy_sync_queue_full_failures` and `semaphore_policy_sync_requeue` CounterVecs were using the names of networksets as labels, which has an almost unbounded possible list of potential values which we obviously can't initialize ahead of time.

I've decided to remove the label because:
1. It has the potential for high cardinality
2. I don't think it's necessarily important information for either metric. I'm not sure if we'd expect requeueing to be networkset specific or if we'd want to split alerts by networkset.
3. If we do have an issue with a specific networkset, that information will be in the logs.